### PR TITLE
fixed tensor size issue

### DIFF
--- a/ML/Pytorch/GANs/4. WGAN-GP/train.py
+++ b/ML/Pytorch/GANs/4. WGAN-GP/train.py
@@ -28,7 +28,7 @@ LAMBDA_GP = 10
 
 transforms = transforms.Compose(
     [
-        transforms.Resize(IMAGE_SIZE),
+        transforms.Resize((IMAGE_SIZE, IMAGE_SIZE)),
         transforms.ToTensor(),
         transforms.Normalize(
             [0.5 for _ in range(CHANNELS_IMG)], [0.5 for _ in range(CHANNELS_IMG)]),


### PR DESCRIPTION
`RuntimeError: The size of tensor a (78) must match the size of tensor b (64) at non-singleton dimension 2`

printing the shape of tensors real and fake inside of the gradient_penalty function in utils.py (directly before the images are interpolated) shows that real has height of 78 instead of 64.
real = torch.Size([64, 3, 78, 64])
fake = torch.Size([64, 3, 64, 64])

Fixed the issue by changing transforms.Resize in train.py from transforms.Resize(IMAGE_SIZE) to transforms.Resize((IMAGE_SIZE, IMAGE_SIZE))